### PR TITLE
Strip AWS ProviderChain to the bare minimum

### DIFF
--- a/awscred.cpp
+++ b/awscred.cpp
@@ -21,10 +21,6 @@
 //----------------------------------------------------------
 // Variables
 //----------------------------------------------------------
-static const char S3FS_AWS_ECS_CONTAINER_CREDENTIALS_RELATIVE_URI[]	= "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
-static const char S3FS_AWS_ECS_CONTAINER_CREDENTIALS_FULL_URI[]		= "AWS_CONTAINER_CREDENTIALS_FULL_URI";
-static const char S3FS_AWS_ECS_CONTAINER_AUTHORIZATION_TOKEN[]		= "AWS_CONTAINER_AUTHORIZATION_TOKEN";
-static const char S3FS_AWS_EC2_METADATA_DISABLED[]					= "AWS_EC2_METADATA_DISABLED";
 static const char S3fsDefaultCredentialsProviderChainTag[]			= "DefaultAWSCredentialsProviderChain";
 
 //----------------------------------------------------------
@@ -32,46 +28,7 @@ static const char S3fsDefaultCredentialsProviderChainTag[]			= "DefaultAWSCreden
 //----------------------------------------------------------
 S3fsAWSCredentialsProviderChain::S3fsAWSCredentialsProviderChain(const char* ssoprofile) : Aws::Auth::AWSCredentialsProviderChain()
 {
-	AddProvider(Aws::MakeShared<Aws::Auth::EnvironmentAWSCredentialsProvider>(S3fsDefaultCredentialsProviderChainTag));
 	AddProvider(Aws::MakeShared<Aws::Auth::ProfileConfigFileAWSCredentialsProvider>(S3fsDefaultCredentialsProviderChainTag));
-	AddProvider(Aws::MakeShared<Aws::Auth::ProcessCredentialsProvider>(S3fsDefaultCredentialsProviderChainTag));
-	AddProvider(Aws::MakeShared<Aws::Auth::STSAssumeRoleWebIdentityCredentialsProvider>(S3fsDefaultCredentialsProviderChainTag));
-	AddProvider(Aws::MakeShared<Aws::Auth::STSProfileCredentialsProvider>(S3fsDefaultCredentialsProviderChainTag));
-
-	// SSO
-	if(ssoprofile){
-		AddProvider(Aws::MakeShared<Aws::Auth::SSOCredentialsProvider>(S3fsDefaultCredentialsProviderChainTag, ssoprofile));
-	}else{
-		AddProvider(Aws::MakeShared<Aws::Auth::SSOCredentialsProvider>(S3fsDefaultCredentialsProviderChainTag));
-	}
-
-	//
-	// ECS TaskRole Credentials only available when ENVIRONMENT VARIABLE is set
-	//
-	const auto relativeUri = Aws::Environment::GetEnv(S3FS_AWS_ECS_CONTAINER_CREDENTIALS_RELATIVE_URI);
-	AWS_LOGSTREAM_DEBUG(S3fsDefaultCredentialsProviderChainTag, "The environment variable value " << S3FS_AWS_ECS_CONTAINER_CREDENTIALS_RELATIVE_URI << " is " << relativeUri);
-
-	const auto absoluteUri = Aws::Environment::GetEnv(S3FS_AWS_ECS_CONTAINER_CREDENTIALS_FULL_URI);
-	AWS_LOGSTREAM_DEBUG(S3fsDefaultCredentialsProviderChainTag, "The environment variable value " << S3FS_AWS_ECS_CONTAINER_CREDENTIALS_FULL_URI << " is " << absoluteUri);
-
-	const auto ec2MetadataDisabled = Aws::Environment::GetEnv(S3FS_AWS_EC2_METADATA_DISABLED);
-	AWS_LOGSTREAM_DEBUG(S3fsDefaultCredentialsProviderChainTag, "The environment variable value " << S3FS_AWS_EC2_METADATA_DISABLED << " is " << ec2MetadataDisabled);
-
-	if(!relativeUri.empty()){
-		AddProvider(Aws::MakeShared<Aws::Auth::TaskRoleCredentialsProvider>(S3fsDefaultCredentialsProviderChainTag, relativeUri.c_str()));
-		AWS_LOGSTREAM_INFO(S3fsDefaultCredentialsProviderChainTag, "Added ECS metadata service credentials provider with relative path: [" << relativeUri << "] to the provider chain.");
-
-	}else if(!absoluteUri.empty()){
-		const auto token = Aws::Environment::GetEnv(S3FS_AWS_ECS_CONTAINER_AUTHORIZATION_TOKEN);
-		AddProvider(Aws::MakeShared<Aws::Auth::TaskRoleCredentialsProvider>(S3fsDefaultCredentialsProviderChainTag, absoluteUri.c_str(), token.c_str()));
-
-		//DO NOT log the value of the authorization token for security purposes.
-		AWS_LOGSTREAM_INFO(S3fsDefaultCredentialsProviderChainTag, "Added ECS credentials provider with URI: [" << absoluteUri << "] to the provider chain with a" << (token.empty() ? "n empty " : " non-empty ") << "authorization token.");
-
-	}else if(Aws::Utils::StringUtils::ToLower(ec2MetadataDisabled.c_str()) != "true"){
-		AddProvider(Aws::MakeShared<Aws::Auth::InstanceProfileCredentialsProvider>(S3fsDefaultCredentialsProviderChainTag));
-		AWS_LOGSTREAM_INFO(S3fsDefaultCredentialsProviderChainTag, "Added EC2 metadata service credentials provider to the provider chain.");
-	}
 }
 
 /*

--- a/awscred.cpp
+++ b/awscred.cpp
@@ -26,7 +26,7 @@ static const char S3fsDefaultCredentialsProviderChainTag[]			= "DefaultAWSCreden
 //----------------------------------------------------------
 // Methods : S3fsAWSCredentialsProviderChain
 //----------------------------------------------------------
-S3fsAWSCredentialsProviderChain::S3fsAWSCredentialsProviderChain(const char* ssoprofile) : Aws::Auth::AWSCredentialsProviderChain()
+S3fsAWSCredentialsProviderChain::S3fsAWSCredentialsProviderChain() : Aws::Auth::AWSCredentialsProviderChain()
 {
 	AddProvider(Aws::MakeShared<Aws::Auth::ProfileConfigFileAWSCredentialsProvider>(S3fsDefaultCredentialsProviderChainTag));
 }

--- a/awscred.h
+++ b/awscred.h
@@ -36,7 +36,7 @@
 class S3fsAWSCredentialsProviderChain : public Aws::Auth::AWSCredentialsProviderChain
 {
 	public:
-		S3fsAWSCredentialsProviderChain(const char* ssoprofile = nullptr);
+		S3fsAWSCredentialsProviderChain();
 };
 
 /*

--- a/awscred_func.cpp
+++ b/awscred_func.cpp
@@ -156,7 +156,7 @@ static const Aws::Utils::DateTime& GetExparationByValidPeriod(const Aws::String&
 const char* VersionS3fsCredential(bool detail)
 {
 	const char short_version_form[]  = "s3fs-fuse-awscred-lib : Version %s (%s)";
-	const char detail_version_form[] = 
+	const char detail_version_form[] =
 		"s3fs-fuse-awscred-lib : Version %s (%s)\n"
 		"s3fs-fuse credential I/F library for AWS\n"
 		"Copyright 2022 Takeshi Nakatani <ggtakec@gmail.com>\n";
@@ -202,24 +202,7 @@ bool InitS3fsCredential(const char* popts, char** pperrstr)
 			std::string	strLowkey	= iter->first;
 			std::string	strValue	= iter->second;
 
-			if(0 == strcasecmp(strLowkey.c_str(), "SSOProfile") || 0 == strcasecmp(strLowkey.c_str(), "SSOProf")){
-				if(strValue.empty()){
-					if(pperrstr){
-						*pperrstr = strdup("Option(SSOProfile) value is empty.");
-					}
-					return false;
-				}
-
-				Aws::String&	ssoprofile = GetSSOProfile();
-				if(!ssoprofile.empty()){
-					if(pperrstr){
-						*pperrstr = strdup("Already specified SSO Profile name.");
-					}
-					return false;
-				}
-				ssoprofile = strValue.c_str();
-
-			}else if(0 == strcasecmp(strLowkey.c_str(), "TokenPeriodSecond") || 0 == strcasecmp(strLowkey.c_str(), "PeriodSec")){
+      if(0 == strcasecmp(strLowkey.c_str(), "TokenPeriodSecond") || 0 == strcasecmp(strLowkey.c_str(), "PeriodSec")){
 				if(strValue.empty()){
 					if(pperrstr){
 						*pperrstr = strdup("Option(SSOProfile) value is empty.");
@@ -419,12 +402,8 @@ bool UpdateS3fsCredential(char** ppaccess_key_id, char** ppserect_access_key, ch
 		*pperrstr = NULL;
 	}
 
-	// Get SSO Profile option
-	const Aws::String&		ssoprofile	= GetSSOProfile();
-	const char*				pSSOProf	= ssoprofile.empty() ? nullptr : ssoprofile.c_str();
-
 	// Create provider chain
-	S3fsAWSCredentialsProviderChain	providerChains(pSSOProf);
+	S3fsAWSCredentialsProviderChain	providerChains;
 	Aws::SDKOptions&		options		= GetSDKOptions();
 	auto					credentials	= providerChains.GetAWSCredentials();
 	bool					result		= true;


### PR DESCRIPTION
we just need it to read the ~/.credentials files according to the specs.